### PR TITLE
Fix remote h5ad staging classloader conflict (0.5.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,15 +67,15 @@ jobs:
           architecture: x64
           distribution: 'temurin'
 
-      - name: Run tests
-        run: make test
-        env:
-          GRADLE_OPTS: '-Dorg.gradle.daemon=false'
-
       - name: Setup Nextflow ${{ inputs.nextflow_version }}
         uses: nf-core/setup-nextflow@v2
         with:
           version: ${{ inputs.nextflow_version }}
+
+      - name: Run tests
+        run: make test
+        env:
+          GRADLE_OPTS: '-Dorg.gradle.daemon=false'
 
       - name: Clean existing plugin
         run: rm -rf ~/.nextflow/plugins/nf-anndata*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Remote h5ad staging classloader conflict** — exclude Guava from the plugin bundle so `CacheHelper.hasher()` uses Nextflow's classpath instead of triggering a PF4J `LinkageError` when staging remote files
+
 ## [0.5.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-02
+
+### Added
+
+- **End-to-end remote staging test** — `AnnDataPluginRemoteTest` installs the plugin and runs Nextflow with a remote h5ad URL to catch PF4J/Guava classloader conflicts that Gradle unit tests miss
+
 ### Fixed
 
 - **Remote h5ad staging classloader conflict** — exclude Guava from the plugin bundle so `CacheHelper.hasher()` uses Nextflow's classpath instead of triggering a PF4J `LinkageError` when staging remote files
@@ -180,6 +186,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Column unique values with `n_unique()`
 - Nextflow plugin integration with `anndata()` function
 
+[0.5.1]: https://github.com/nictru/nf-anndata/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/nictru/nf-anndata/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/nictru/nf-anndata/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/nictru/nf-anndata/compare/v0.3.4...v0.4.0

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'io.nextflow.nextflow-plugin' version '1.0.0-beta.10'
 }
 
-version = '0.5.0'
+version = '0.5.1'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,11 @@ repositories {
 }
 
 configurations {
-    // Exclude slf4j-api from runtime - Nextflow provides it
+    // Exclude libraries provided by Nextflow at runtime to avoid PF4J classloader conflicts
     runtimeClasspath.exclude group: 'org.slf4j', module: 'slf4j-api'
+    runtimeClasspath.exclude group: 'com.google.guava', module: 'guava'
+    runtimeClasspath.exclude group: 'com.google.guava', module: 'failureaccess'
+    runtimeClasspath.exclude group: 'com.google.guava', module: 'listenablefuture'
 }
 
 dependencies {

--- a/src/test/groovy/acme/plugin/AnnDataPluginRemoteTest.groovy
+++ b/src/test/groovy/acme/plugin/AnnDataPluginRemoteTest.groovy
@@ -63,11 +63,24 @@ class AnnDataPluginRemoteTest extends Specification {
         if (fromEnv) {
             return fromEnv
         }
-        for (def candidate : ['nextflow', '/usr/local/bin/nextflow', "${System.getProperty('user.home')}/.micromamba/envs/nf-core/bin/nextflow"]) {
+
+        def pathEnv = System.getenv('PATH') ?: ''
+        for (def dir : pathEnv.split(':')) {
+            if (!dir) {
+                continue
+            }
+            def candidate = Paths.get(dir, 'nextflow')
+            if (Files.isExecutable(candidate)) {
+                return candidate.toString()
+            }
+        }
+
+        for (def candidate : ['/usr/local/bin/nextflow', "${System.getProperty('user.home')}/.micromamba/envs/nf-core/bin/nextflow"]) {
             if (Files.isExecutable(Paths.get(candidate))) {
                 return candidate
             }
         }
+
         return null
     }
 

--- a/src/test/groovy/acme/plugin/AnnDataPluginRemoteTest.groovy
+++ b/src/test/groovy/acme/plugin/AnnDataPluginRemoteTest.groovy
@@ -1,0 +1,130 @@
+package acme.plugin
+
+import spock.lang.Requires
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * End-to-end test for remote h5ad staging through the installed Nextflow plugin.
+ *
+ * Gradle unit tests run on a single classloader and cannot reproduce PF4J/Guava
+ * loader conflicts. This test installs the plugin and runs Nextflow with a
+ * remote HTTP URL so {@code CacheHelper.hasher()} is exercised in production conditions.
+ */
+class AnnDataPluginRemoteTest extends Specification {
+
+    static final String REMOTE_URL =
+        'https://github.com/nictru/nf-anndata/raw/refs/heads/main/src/test/data/test_cases/pbmc3k_processed.h5ad'
+
+    static final int EXPECTED_N_OBS = 2638
+    static final int EXPECTED_N_VARS = 1838
+
+    static Path projectRoot() {
+        Paths.get('').toAbsolutePath()
+    }
+
+    static String pluginVersion() {
+        def matcher = projectRoot().resolve('build.gradle').text =~ /version = '([^']+)'/
+        assert matcher.find()
+        return matcher.group(1)
+    }
+
+    static boolean nextflowAvailable() {
+        def cmd = nextflowCommand()
+        if (!cmd) {
+            return false
+        }
+        try {
+            def proc = new ProcessBuilder(cmd, '-version').redirectErrorStream(true).start()
+            return proc.waitFor() == 0
+        } catch (IOException ignored) {
+            return false
+        }
+    }
+
+    static boolean networkAvailable() {
+        try {
+            new URL('https://github.com').openConnection().with {
+                connectTimeout = 5000
+                readTimeout = 5000
+                connect()
+            }
+            return true
+        } catch (Exception ignored) {
+            return false
+        }
+    }
+
+    static String nextflowCommand() {
+        def fromEnv = System.getenv('NEXTFLOW_CMD')
+        if (fromEnv) {
+            return fromEnv
+        }
+        for (def candidate : ['nextflow', '/usr/local/bin/nextflow', "${System.getProperty('user.home')}/.micromamba/envs/nf-core/bin/nextflow"]) {
+            if (Files.isExecutable(Paths.get(candidate))) {
+                return candidate
+            }
+        }
+        return null
+    }
+
+    static void installPlugin() {
+        def pluginsDir = Paths.get(System.getProperty('user.home'), '.nextflow', 'plugins')
+        if (Files.exists(pluginsDir)) {
+            Files.list(pluginsDir)
+                .filter { it.fileName.toString().startsWith('nf-anndata-') }
+                .forEach { path ->
+                    path.toFile().deleteDir()
+                }
+        }
+
+        def proc = new ProcessBuilder('./gradlew', 'installPlugin', '-q')
+            .directory(projectRoot().toFile())
+            .redirectErrorStream(true)
+            .start()
+        def output = proc.inputStream.text
+        assert proc.waitFor() == 0 : "installPlugin failed:\n${output}"
+    }
+
+    @Requires({ nextflowAvailable() && networkAvailable() })
+    def 'remote HTTP h5ad staging works via installed plugin'() {
+        given:
+        installPlugin()
+        def workDir = Files.createTempDirectory('nf-anndata-plugin-remote-test')
+
+        workDir.resolve('nextflow.config').text = """\
+plugins {
+    id 'nf-anndata@${pluginVersion()}'
+}
+""".stripIndent()
+
+        workDir.resolve('main.nf').text = """\
+include { anndata } from 'plugin/nf-anndata'
+
+workflow {
+    def ad = anndata(file('${REMOTE_URL}'))
+    println "n_obs: \${ad.n_obs}"
+    println "n_vars: \${ad.n_vars}"
+}
+""".stripIndent()
+
+        when:
+        def proc = new ProcessBuilder(nextflowCommand(), 'run', 'main.nf')
+            .directory(workDir.toFile())
+            .redirectErrorStream(true)
+            .start()
+        def output = proc.inputStream.text
+        def exitCode = proc.waitFor()
+
+        then:
+        assert exitCode == 0 : "Nextflow failed (exit ${exitCode}):\n${output}"
+        output.contains("n_obs: ${EXPECTED_N_OBS}")
+        output.contains("n_vars: ${EXPECTED_N_VARS}")
+
+        cleanup:
+        workDir.toFile().deleteDir()
+    }
+}

--- a/validation/nextflow.config
+++ b/validation/nextflow.config
@@ -1,3 +1,3 @@
 plugins {
-    id 'nf-anndata@0.5.0'
+    id 'nf-anndata@0.5.1'
 }


### PR DESCRIPTION
## Summary

- Exclude Guava from the plugin bundle to fix a `LinkageError` when staging remote h5ad files (introduced in 0.5.0 via the Zarr/`cdm-core` dependency)
- Add `AnnDataPluginRemoteTest`, an end-to-end test that installs the plugin and runs Nextflow with a remote HTTP URL — catches PF4J classloader issues that Gradle unit tests cannot
- Set up Nextflow before `./gradlew test` in CI so the new test runs in GitHub Actions
- Bump version to **0.5.1**

## Root cause

0.5.0 bundled `guava-33.4.8-jre.jar` (transitive from `zarr-java` → `cdm-core`) alongside Nextflow's own Guava. Remote file staging calls `CacheHelper.hasher()`, which crosses the PF4J plugin/app classloader boundary and fails with:

```
loader constraint violation: ... com.google.common.hash.Hasher
```

Local files were unaffected because `stageIfRemote()` returns early without calling `CacheHelper`.

## Test plan

- [x] `AnnDataPluginRemoteTest` fails on 0.5.0, passes on this branch
- [x] Full `./gradlew test` passes
- [x] CI green on all matrix jobs (Java 17/21 × NF 24.10/latest-stable/latest-edge)
- [x] Plugin zip no longer contains `lib/guava-*.jar`
- [x] Manual verification: `anndata(file('https://github.com/nictru/nf-anndata/raw/.../pbmc3k_processed.h5ad'))` on Nextflow 25.10.4

## After merge

Tag and release **v0.5.1** from `main` (changelog and version refs are already updated).